### PR TITLE
feat: 영화 상세보기 모달에 url 연결

### DIFF
--- a/app/(anon)/movie-detail/components/MovieDetailModal.tsx
+++ b/app/(anon)/movie-detail/components/MovieDetailModal.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { useParams } from "next/navigation";
 import Modal from "@/app/components/Modal";
 import MoviePreviewInfo from "./MoviePreviewInfo";
 import MovieReviewList from "./MovieReviewList";
@@ -13,13 +12,7 @@ interface ModalProps {
   movieId?: number;
 }
 
-const MovieDetailModal = ({ setModal, movieId: propMovieId }: ModalProps) => {
-  const params = useParams();
-
-  // URL에서 movieId 파싱
-  const urlMovieId = params?.id ? Number(params.id) : null;
-  const movieId = propMovieId || urlMovieId || 550; // Fight Club (실제 TMDB 영화 ID)
-
+const MovieDetailModal = ({ setModal, movieId = 550 }: ModalProps) => {
   // 접힘 상태에서는 preview만 사용
   const [moviePreview, setMoviePreview] = useState<MoviePreviewDto | null>(
     null

--- a/app/(anon)/movies/[id]/page.tsx
+++ b/app/(anon)/movies/[id]/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import React from "react";
+import { useParams } from "next/navigation";
+import MovieDetailModal from "../../movie-detail/components/MovieDetailModal";
+
+export default function MovieDetailPage() {
+  const params = useParams();
+  const movieId = Number(params.id);
+
+  return (
+    <div className="min-h-screen bg-[#1D1F28] flex items-center justify-center">
+      <MovieDetailModal
+        setModal={() => window.history.back()}
+        movieId={movieId}
+      />
+    </div>
+  );
+}

--- a/app/(anon)/search/page.tsx
+++ b/app/(anon)/search/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useState, useEffect } from "react";
+import { useCallback, useState, useEffect, Suspense } from "react";
 import SearchInput from "./components/SearchInput";
 import SearchResult from "./components/SearchResult";
 import RecommendedMovieList from "./components/RecommendedMovieList";
 
-export default function SearchPage() {
+function SearchPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -61,5 +61,15 @@ export default function SearchPage() {
         )}
       </div>
     </section>
+  );
+}
+
+export default function SearchPage() {
+  return (
+    <Suspense
+      fallback={<div className="text-white text-center">로딩중...</div>}
+    >
+      <SearchPageContent />
+    </Suspense>
   );
 }

--- a/app/api/(anon)/movies/[id]/route.ts
+++ b/app/api/(anon)/movies/[id]/route.ts
@@ -1,18 +1,20 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { GetMovieDetailsUseCase } from "@/backend/application/movies/usecases/GetMovieDetailsUseCase";
 
 export async function GET(
-  req: Request,
-  { params }: { params: { id: string } }
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
 ) {
-  const id = Number(params.id);
-  if (isNaN(id)) {
+  const { id } = await params;
+  const movieId = Number(id);
+
+  if (isNaN(movieId)) {
     return NextResponse.json({ error: "Invalid movie id" }, { status: 400 });
   }
 
   const usecase = new GetMovieDetailsUseCase();
   try {
-    const movie = await usecase.execute(id);
+    const movie = await usecase.execute(movieId);
     if (!movie) {
       return NextResponse.json({ error: "Movie not found" }, { status: 404 });
     }


### PR DESCRIPTION
## 📄 작업 내용

- /movies/[id] 페이지 생성하여, url을 통해 영화 상세보기 모달창을 열 수 있도록 구현했습니다.
- 클라이언트 컴포넌트에서 useSearchParams()를 직접 사용하면 빌드에러가 발생하므로,
   Suspense Boundary로 감싸 에러를 해결했습니다.

>  영화 상세보기 url은 아래 첨부한 이미지처럼 `http://localhost:3000/movies/[id]`로 요청하시면 됩니다.
<img width="1383" height="919" alt="image" src="https://github.com/user-attachments/assets/6842b680-e494-4b9b-aff0-37f3732dbbed" />
<br><br>

## 💡 참고 사항

> 팀원이 참고해야 할 부분이 있다면 알려주세요

<br><br>

## 🏷️ Issue67
<!-- closed #67  -->
